### PR TITLE
Voeg site-brede dark mode toe met persistente theme-toggle

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,20 +5,23 @@ import Contact from './Pages/Contact'
 import Discover from './Pages/Discover'
 import DetailPage from './Components/DetailPage'
 import { BrowserRouter, Routes, Route } from 'react-router-dom'
+import { ThemeProvider } from './Components/ThemeProvider'
 
 function App() {
   return (
-    <BrowserRouter basename="/portfolio-website">
-      <Routes>
-        <Route path="/" element={<Navigation />}>
-          <Route index element={<Home />} />
-          <Route path="about" element={<About />} />
-          <Route path="contact" element={<Contact />} />
-          <Route path="discover" element={<Discover />} />
-          <Route path="projects/:id" element={<DetailPage />} />
-        </Route>
-      </Routes>
-    </BrowserRouter>
+    <ThemeProvider>
+      <BrowserRouter basename="/portfolio-website">
+        <Routes>
+          <Route path="/" element={<Navigation />}>
+            <Route index element={<Home />} />
+            <Route path="about" element={<About />} />
+            <Route path="contact" element={<Contact />} />
+            <Route path="discover" element={<Discover />} />
+            <Route path="projects/:id" element={<DetailPage />} />
+          </Route>
+        </Routes>
+      </BrowserRouter>
+    </ThemeProvider>
   )
 }
 

--- a/src/Components/DetailPage.jsx
+++ b/src/Components/DetailPage.jsx
@@ -18,15 +18,15 @@ function DetailPage() {
     return (
       <Layout>
         <main className="mx-auto max-w-xl px-6 py-20 text-center">
-          <h2 className="text-2xl font-semibold text-zinc-900">
+          <h2 className="text-2xl font-semibold text-zinc-900 dark:text-zinc-100">
             Project niet gevonden
           </h2>
-          <p className="mt-2 text-zinc-600">
+          <p className="mt-2 text-zinc-600 dark:text-zinc-400">
             Het project bestaat niet of is verplaatst.
           </p>
           <Link
             to="/discover"
-            className="mt-6 inline-flex rounded-full bg-zinc-900 px-5 py-2.5 text-sm font-semibold text-white transition hover:bg-zinc-800"
+            className="mt-6 inline-flex rounded-full bg-zinc-900 px-5 py-2.5 text-sm font-semibold text-white transition hover:bg-zinc-800 dark:bg-zinc-100 dark:text-zinc-900 dark:hover:bg-zinc-200"
           >
             Terug naar projecten
           </Link>
@@ -42,13 +42,13 @@ function DetailPage() {
         {/* Back button */}
         <Link
           to="/discover"
-          className="inline-flex rounded-full border border-zinc-300 bg-zinc-100 px-4 py-2 text-sm font-semibold text-zinc-800 transition hover:bg-zinc-200"
+          className="inline-flex rounded-full border border-zinc-300 bg-zinc-100 px-4 py-2 text-sm font-semibold text-zinc-800 transition hover:bg-zinc-200 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-200 dark:hover:bg-zinc-700"
         >
           ← Terug naar projecten
         </Link>
 
         {/* Hero section */}
-        <section className="mt-6 overflow-hidden rounded-3xl border border-zinc-200 bg-white shadow-sm">
+        <section className="mt-6 overflow-hidden rounded-3xl border border-zinc-200 bg-white shadow-sm dark:border-zinc-800 dark:bg-zinc-900">
           <img
             src={project.image}
             alt={project.name}
@@ -57,19 +57,19 @@ function DetailPage() {
 
           <div className="space-y-4 p-6 md:p-8">
             <div className="flex flex-wrap items-center gap-2">
-              <span className="rounded-full bg-zinc-900 px-3 py-1 text-xs font-semibold text-white">
+              <span className="rounded-full bg-zinc-900 px-3 py-1 text-xs font-semibold text-white dark:bg-zinc-100 dark:text-zinc-900">
                 {project.category}
               </span>
-              <span className="rounded-full border border-zinc-300 bg-zinc-100 px-3 py-1 text-xs text-zinc-700">
+              <span className="rounded-full border border-zinc-300 bg-zinc-100 px-3 py-1 text-xs text-zinc-700 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-300">
                 {project.year}
               </span>
             </div>
 
-            <h1 className="text-4xl font-semibold tracking-tight text-zinc-950">
+            <h1 className="text-4xl font-semibold tracking-tight text-zinc-950 dark:text-zinc-50">
               {project.name}
             </h1>
 
-            <p className="max-w-3xl leading-8 text-zinc-700">
+            <p className="max-w-3xl leading-8 text-zinc-700 dark:text-zinc-300">
               {project.description}
             </p>
 
@@ -77,7 +77,7 @@ function DetailPage() {
               {project.stack?.map((item) => (
                 <li
                   key={item}
-                  className="rounded-full border border-zinc-300 bg-zinc-50 px-3 py-1 text-xs font-semibold text-zinc-700"
+                  className="rounded-full border border-zinc-300 bg-zinc-50 px-3 py-1 text-xs font-semibold text-zinc-700 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-300"
                 >
                   {item}
                 </li>
@@ -92,7 +92,7 @@ function DetailPage() {
             {project.details.map((detail, index) => (
               <article
                 key={index}
-                className="overflow-hidden rounded-2xl border border-zinc-200 bg-white shadow-sm"
+                className="overflow-hidden rounded-2xl border border-zinc-200 bg-white shadow-sm dark:border-zinc-800 dark:bg-zinc-900"
               >
                 <img
                   src={detail.image}
@@ -102,11 +102,11 @@ function DetailPage() {
 
                 <div className="p-6">
                   {detail.title && (
-                    <h2 className="text-xl font-semibold text-zinc-900">
+                    <h2 className="text-xl font-semibold text-zinc-900 dark:text-zinc-100">
                       {detail.title}
                     </h2>
                   )}
-                  <p className="mt-3 text-sm leading-7 text-zinc-700">
+                  <p className="mt-3 text-sm leading-7 text-zinc-700 dark:text-zinc-300">
                     {detail.text}
                   </p>
                 </div>

--- a/src/Components/Footer.jsx
+++ b/src/Components/Footer.jsx
@@ -1,13 +1,9 @@
-import { Link } from 'react-router-dom'
-
 const Footer = () => {
   const year = new Date().getFullYear()
 
   return (
-    <footer className="mt-14 border-t border-zinc-300 bg-zinc-900 text-zinc-200">
+    <footer className="mt-14 border-t border-zinc-300 bg-zinc-900 text-zinc-200 dark:border-zinc-800 dark:bg-black">
       <div className="mx-auto grid w-full max-w-6xl gap-8 px-6 py-10 text-left md:grid-cols-[1.2fr_0.8fr_0.8fr]">
-        
-        {/* Brand */}
         <section>
           <p className="text-xs font-semibold uppercase tracking-[0.18em] text-zinc-400">
             Portfolio
@@ -22,9 +18,6 @@ const Footer = () => {
           </p>
         </section>
 
-   
-
-        {/* Contact */}
         <section>
           <h3 className="text-sm font-semibold uppercase tracking-wide text-zinc-300">
             Contact
@@ -60,15 +53,11 @@ const Footer = () => {
         </section>
       </div>
 
-      {/* Bottom bar */}
       <div className="border-t border-zinc-800">
         <div className="mx-auto flex w-full max-w-6xl flex-col gap-2 px-6 py-4 text-xs text-zinc-500 md:flex-row md:items-center md:justify-between">
           <p>© {year} Ricky Saarloos. Alle rechten voorbehouden.</p>
           <p>
-            Built with{' '}
-            <span className="font-medium text-zinc-300">
-              React + Vite
-            </span>
+            Built with <span className="font-medium text-zinc-300">React + Vite</span>
           </p>
         </div>
       </div>

--- a/src/Components/Layout.jsx
+++ b/src/Components/Layout.jsx
@@ -1,20 +1,18 @@
 import Footer from './Footer'
 
-
 const githubLogo = `${import.meta.env.BASE_URL}images/pngimg.com - github_PNG40.png`
-
 
 const Layout = ({ children }) => {
   return (
-    <div className="flex min-h-screen flex-col bg-zinc-100">
+    <div className="flex min-h-screen flex-col bg-zinc-100 transition-colors dark:bg-zinc-950">
       <a
         href="https://github.com/rickysaarloos"
         target="_blank"
         rel="noopener noreferrer"
-        className="fixed right-6 top-6 z-50 rounded-full bg-white/80 p-2 shadow-md backdrop-blur transition hover:scale-105 hover:bg-white"
+        className="fixed right-6 top-6 z-50 rounded-full bg-white/80 p-2 shadow-md backdrop-blur transition hover:scale-105 hover:bg-white dark:bg-zinc-900/80 dark:hover:bg-zinc-900"
         aria-label="GitHub profiel"
       >
-            <img src={githubLogo} alt="GitHub" className="h-9 w-9" />
+        <img src={githubLogo} alt="GitHub" className="h-9 w-9 rounded-full" />
       </a>
       <main className="flex-1">{children}</main>
       <Footer />

--- a/src/Components/ProjectCard.jsx
+++ b/src/Components/ProjectCard.jsx
@@ -8,7 +8,7 @@ function ProjectCard({ project }) {
       type="button"
       onClick={() => navigate(`/projects/${project.id}`)}
       aria-label={`Open project ${project.name}`}
-      className="group overflow-hidden rounded-2xl border border-zinc-200 bg-white text-left shadow-sm transition duration-300 hover:-translate-y-1 hover:border-zinc-300 hover:shadow-xl"
+      className="group overflow-hidden rounded-2xl border border-zinc-200 bg-white text-left shadow-sm transition duration-300 hover:-translate-y-1 hover:border-zinc-300 hover:shadow-xl dark:border-zinc-800 dark:bg-zinc-900 dark:hover:border-zinc-700"
     >
       {/* Image */}
       <div className="relative">
@@ -27,18 +27,18 @@ function ProjectCard({ project }) {
       {/* Content */}
       <div className="space-y-3 p-5">
         <div className="flex items-center justify-between gap-3">
-          <h2 className="text-lg font-semibold tracking-tight text-zinc-900">
+          <h2 className="text-lg font-semibold tracking-tight text-zinc-900 dark:text-zinc-100">
             {project.name}
           </h2>
 
           {project.year && (
-            <span className="rounded-full border border-zinc-300 bg-zinc-100 px-2.5 py-1 text-xs font-medium text-zinc-700">
+            <span className="rounded-full border border-zinc-300 bg-zinc-100 px-2.5 py-1 text-xs font-medium text-zinc-700 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-300">
               {project.year}
             </span>
           )}
         </div>
 
-        <p className="text-sm leading-7 text-zinc-600">
+        <p className="text-sm leading-7 text-zinc-600 dark:text-zinc-400">
           {project.description}
         </p>
 
@@ -47,7 +47,7 @@ function ProjectCard({ project }) {
             {project.stack.slice(0, 3).map((item) => (
               <li
                 key={item}
-                className="rounded-full border border-zinc-300 bg-zinc-50 px-2.5 py-1 text-xs font-medium text-zinc-700"
+                className="rounded-full border border-zinc-300 bg-zinc-50 px-2.5 py-1 text-xs font-medium text-zinc-700 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-300"
               >
                 {item}
               </li>
@@ -55,7 +55,7 @@ function ProjectCard({ project }) {
           </ul>
         )}
 
-        <p className="text-sm font-semibold text-zinc-800 transition group-hover:text-zinc-950">
+        <p className="text-sm font-semibold text-zinc-800 transition group-hover:text-zinc-950 dark:text-zinc-300 dark:group-hover:text-zinc-100">
           Bekijk details →
         </p>
       </div>

--- a/src/Components/ThemeProvider.jsx
+++ b/src/Components/ThemeProvider.jsx
@@ -1,0 +1,34 @@
+import { useEffect, useMemo, useState } from 'react'
+import { ThemeContext } from './themeContext'
+
+const getInitialTheme = () => {
+  if (typeof window === 'undefined') return 'light'
+
+  const savedTheme = window.localStorage.getItem('theme')
+  if (savedTheme === 'light' || savedTheme === 'dark') {
+    return savedTheme
+  }
+
+  return window.matchMedia('(prefers-color-scheme: dark)').matches
+    ? 'dark'
+    : 'light'
+}
+
+export function ThemeProvider({ children }) {
+  const [theme, setTheme] = useState(getInitialTheme)
+
+  useEffect(() => {
+    document.documentElement.classList.toggle('dark', theme === 'dark')
+    window.localStorage.setItem('theme', theme)
+  }, [theme])
+
+  const value = useMemo(
+    () => ({
+      theme,
+      toggleTheme: () => setTheme((current) => (current === 'dark' ? 'light' : 'dark')),
+    }),
+    [theme],
+  )
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>
+}

--- a/src/Components/themeContext.js
+++ b/src/Components/themeContext.js
@@ -1,0 +1,13 @@
+import { createContext, useContext } from 'react'
+
+export const ThemeContext = createContext(null)
+
+export function useTheme() {
+  const context = useContext(ThemeContext)
+
+  if (!context) {
+    throw new Error('useTheme must be used within a ThemeProvider')
+  }
+
+  return context
+}

--- a/src/Pages/About.jsx
+++ b/src/Pages/About.jsx
@@ -44,21 +44,21 @@ const About = () => {
         {/* HERO */}
         <section className="grid items-center gap-12 lg:grid-cols-2">
           <div>
-            <span className="inline-block rounded-full bg-zinc-100 px-3 py-1 text-xs font-semibold text-zinc-600">
+            <span className="inline-block rounded-full bg-zinc-100 px-3 py-1 text-xs font-semibold text-zinc-600 dark:bg-zinc-800 dark:text-zinc-300">
               About Me
             </span>
 
-            <h1 className="mt-4 text-4xl font-semibold text-zinc-950 md:text-5xl">
+            <h1 className="mt-4 text-4xl font-semibold text-zinc-950 dark:text-zinc-50 md:text-5xl">
               Ricky Saarloos
             </h1>
 
-            <p className="mt-6 text-zinc-700 leading-8">
+            <p className="mt-6 text-zinc-700 leading-8 dark:text-zinc-300">
               Ik ben software development student aan het Techniek College Rotterdam
               en specialiseer me in het ontwerpen en bouwen van moderne webinterfaces.
               Mijn doel is digitale producten te maken die snel, toegankelijk en professioneel aanvoelen.
             </p>
 
-            <p className="mt-4 text-zinc-700 leading-8">
+            <p className="mt-4 text-zinc-700 leading-8 dark:text-zinc-300">
               Ik combineer technische precisie met visuele kwaliteit: van componentstructuur
               en performance tot typografie, spacing en gebruikservaring.
             </p>
@@ -66,13 +66,13 @@ const About = () => {
             <div className="mt-8 flex gap-4">
               <Link
                 to="/discover"
-                className="rounded-full border border-zinc-300 px-5 py-2.5 text-sm font-semibold text-zinc-800 hover:bg-zinc-100"
+                className="rounded-full border border-zinc-300 px-5 py-2.5 text-sm font-semibold text-zinc-800 hover:bg-zinc-100 dark:border-zinc-700 dark:text-zinc-200 dark:hover:bg-zinc-800"
               >
                 Bekijk mijn werk
               </Link>
               <Link
                 to="/contact"
-                className="rounded-full border border-zinc-300 px-5 py-2.5 text-sm font-semibold text-zinc-800 hover:bg-zinc-100"
+                className="rounded-full border border-zinc-300 px-5 py-2.5 text-sm font-semibold text-zinc-800 hover:bg-zinc-100 dark:border-zinc-700 dark:text-zinc-200 dark:hover:bg-zinc-800"
               >
                 Neem contact op
               </Link>
@@ -107,12 +107,12 @@ const About = () => {
           {highlights.map((item) => (
             <div
               key={item.label}
-              className="rounded-2xl border border-zinc-200 bg-white p-6 shadow-sm"
+              className="rounded-2xl border border-zinc-200 bg-white p-6 shadow-sm dark:border-zinc-800 dark:bg-zinc-900"
             >
-              <p className="text-3xl font-semibold text-zinc-950">
+              <p className="text-3xl font-semibold text-zinc-950 dark:text-zinc-100">
                 {item.value}
               </p>
-              <p className="mt-2 text-sm text-zinc-600">
+              <p className="mt-2 text-sm text-zinc-600 dark:text-zinc-400">
                 {item.label}
               </p>
             </div>
@@ -120,8 +120,8 @@ const About = () => {
         </section>
 
         {/* Expertise */}
-        <section className="rounded-3xl border border-zinc-200 bg-white p-8 shadow-sm">
-          <h2 className="text-2xl font-semibold text-zinc-900">
+        <section className="rounded-3xl border border-zinc-200 bg-white p-8 shadow-sm dark:border-zinc-800 dark:bg-zinc-900">
+          <h2 className="text-2xl font-semibold text-zinc-900 dark:text-zinc-100">
             Waar ik waarde toevoeg
           </h2>
 
@@ -129,19 +129,19 @@ const About = () => {
             {expertise.map((item) => (
               <div
                 key={item.title}
-                className="rounded-2xl bg-zinc-50 p-6"
+                className="rounded-2xl bg-zinc-50 p-6 dark:bg-zinc-800/50"
               >
-                <h3 className="text-lg font-semibold text-zinc-900">
+                <h3 className="text-lg font-semibold text-zinc-900 dark:text-zinc-100">
                   {item.title}
                 </h3>
-                <p className="mt-3 text-sm text-zinc-700 leading-7">
+                <p className="mt-3 text-sm text-zinc-700 leading-7 dark:text-zinc-300">
                   {item.description}
                 </p>
                 <div className="mt-4 flex flex-wrap gap-2">
                   {item.stack.map((tech) => (
                     <span
                       key={tech}
-                      className="rounded-full border border-zinc-300 bg-white px-3 py-1 text-xs text-zinc-700"
+                      className="rounded-full border border-zinc-300 bg-white px-3 py-1 text-xs text-zinc-700 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-300"
                     >
                       {tech}
                     </span>
@@ -153,13 +153,13 @@ const About = () => {
         </section>
 
         {/* Tech stack */}
-        <section className="rounded-3xl bg-zinc-900 p-8 text-white">
+        <section className="rounded-3xl bg-zinc-900 p-8 text-white dark:bg-black">
           <h2 className="text-2xl font-semibold">Tech stack</h2>
           <ul className="mt-6 flex flex-wrap gap-3">
             {skills.map((skill) => (
               <li
                 key={skill}
-                className="rounded-full bg-zinc-800 px-4 py-1.5 text-sm"
+                className="rounded-full bg-zinc-800 px-4 py-1.5 text-sm dark:bg-zinc-700"
               >
                 {skill}
               </li>

--- a/src/Pages/Contact.jsx
+++ b/src/Pages/Contact.jsx
@@ -57,19 +57,19 @@ const Contact = () => {
   return (
     <Layout>
       <main className="mx-auto w-full max-w-6xl px-6 py-14">
-        <section className="grid gap-10 rounded-3xl border border-zinc-200 bg-white p-8 shadow-sm lg:grid-cols-[1fr_1.1fr]">
+        <section className="grid gap-10 rounded-3xl border border-zinc-200 bg-white p-8 shadow-sm dark:border-zinc-800 dark:bg-zinc-900 lg:grid-cols-[1fr_1.1fr]">
 
           {/* LEFT SIDE */}
           <div>
-            <span className="inline-flex rounded-full bg-zinc-100 px-3 py-1 text-xs font-semibold text-zinc-600">
+            <span className="inline-flex rounded-full bg-zinc-100 px-3 py-1 text-xs font-semibold text-zinc-600 dark:bg-zinc-800 dark:text-zinc-300">
               Contact
             </span>
 
-            <h1 className="mt-4 text-4xl font-semibold text-zinc-950 md:text-5xl">
+            <h1 className="mt-4 text-4xl font-semibold text-zinc-950 dark:text-zinc-50 md:text-5xl">
               Laten we samenwerken
             </h1>
 
-            <p className="mt-6 max-w-xl text-zinc-700 leading-8">
+            <p className="mt-6 max-w-xl text-zinc-700 leading-8 dark:text-zinc-300">
               Werk je aan een website of productidee en zoek je een developer
               die design en techniek combineert? Stuur me een bericht
               en ik kom snel bij je terug.
@@ -79,7 +79,7 @@ const Contact = () => {
               {contactHighlights.map((item) => (
                 <li
                   key={item.value}
-                  className="rounded-full border border-zinc-300 bg-zinc-100 px-3 py-1.5 text-sm"
+                  className="rounded-full border border-zinc-300 bg-zinc-100 px-3 py-1.5 text-sm dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-200"
                 >
                   <span className="font-semibold">{item.value}</span> · {item.label}
                 </li>
@@ -91,12 +91,12 @@ const Contact = () => {
                 <Link
                   key={item.to}
                   to={item.to}
-                  className="block rounded-2xl border border-zinc-200 bg-zinc-50 p-4 transition hover:bg-zinc-100"
+                  className="block rounded-2xl border border-zinc-200 bg-zinc-50 p-4 transition hover:bg-zinc-100 dark:border-zinc-700 dark:bg-zinc-800/60 dark:hover:bg-zinc-800"
                 >
-                  <p className="text-sm font-semibold text-zinc-900">
+                  <p className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">
                     {item.title}
                   </p>
-                  <p className="mt-1 text-sm text-zinc-600">
+                  <p className="mt-1 text-sm text-zinc-600 dark:text-zinc-400">
                     {item.description}
                   </p>
                 </Link>
@@ -107,53 +107,53 @@ const Contact = () => {
           {/* RIGHT SIDE FORM */}
           <form
             onSubmit={onSubmit}
-            className="rounded-2xl border border-zinc-200 bg-zinc-50 p-6 shadow-sm"
+            className="rounded-2xl border border-zinc-200 bg-zinc-50 p-6 shadow-sm dark:border-zinc-700 dark:bg-zinc-800/40"
           >
-            <h2 className="text-xl font-semibold text-zinc-900">
+            <h2 className="text-xl font-semibold text-zinc-900 dark:text-zinc-100">
               Stuur een bericht
             </h2>
       
             <div className="mt-6 grid gap-4 md:grid-cols-2">
-              <label className="flex flex-col gap-2 text-sm font-medium text-zinc-700">
+              <label className="flex flex-col gap-2 text-sm font-medium text-zinc-700 dark:text-zinc-300">
                 First Name
                 <input
                   type="text"
                   name="first_name"
                   required
-                  className="rounded-xl border border-zinc-300 bg-white px-3 py-2.5 outline-none focus:border-zinc-500 focus:ring-2 focus:ring-zinc-300"
+                  className="rounded-xl border border-zinc-300 bg-white px-3 py-2.5 outline-none focus:border-zinc-500 focus:ring-2 focus:ring-zinc-300 dark:border-zinc-600 dark:bg-zinc-900 dark:text-zinc-100 dark:focus:border-zinc-400 dark:focus:ring-zinc-700"
                   placeholder="Ricky"
                 />
               </label>
 
-              <label className="flex flex-col gap-2 text-sm font-medium text-zinc-700">
+              <label className="flex flex-col gap-2 text-sm font-medium text-zinc-700 dark:text-zinc-300">
                 Last Name
                 <input
                   type="text"
                   name="last_name"
                   required
-                  className="rounded-xl border border-zinc-300 bg-white px-3 py-2.5 outline-none focus:border-zinc-500 focus:ring-2 focus:ring-zinc-300"
+                  className="rounded-xl border border-zinc-300 bg-white px-3 py-2.5 outline-none focus:border-zinc-500 focus:ring-2 focus:ring-zinc-300 dark:border-zinc-600 dark:bg-zinc-900 dark:text-zinc-100 dark:focus:border-zinc-400 dark:focus:ring-zinc-700"
                   placeholder="Saarloos"
                 />
               </label>
             </div>
 
-            <label className="mt-4 flex flex-col gap-2 text-sm font-medium text-zinc-700">
+            <label className="mt-4 flex flex-col gap-2 text-sm font-medium text-zinc-700 dark:text-zinc-300">
               Email
               <input
                 type="email"
                 name="email"
                 required
-                className="rounded-xl border border-zinc-300 bg-white px-3 py-2.5 outline-none focus:border-zinc-500 focus:ring-2 focus:ring-zinc-300"
+                className="rounded-xl border border-zinc-300 bg-white px-3 py-2.5 outline-none focus:border-zinc-500 focus:ring-2 focus:ring-zinc-300 dark:border-zinc-600 dark:bg-zinc-900 dark:text-zinc-100 dark:focus:border-zinc-400 dark:focus:ring-zinc-700"
                 placeholder="you@company.com"
               />
             </label>
 
-            <label className="mt-4 flex flex-col gap-2 text-sm font-medium text-zinc-700">
+            <label className="mt-4 flex flex-col gap-2 text-sm font-medium text-zinc-700 dark:text-zinc-300">
               Message
               <textarea
                 name="message"
                 required
-                className="min-h-36 rounded-xl border border-zinc-300 bg-white px-3 py-2.5 outline-none focus:border-zinc-500 focus:ring-2 focus:ring-zinc-300"
+                className="min-h-36 rounded-xl border border-zinc-300 bg-white px-3 py-2.5 outline-none focus:border-zinc-500 focus:ring-2 focus:ring-zinc-300 dark:border-zinc-600 dark:bg-zinc-900 dark:text-zinc-100 dark:focus:border-zinc-400 dark:focus:ring-zinc-700"
                 placeholder="Vertel kort over je project, planning en doelen..."
               />
             </label>
@@ -161,13 +161,13 @@ const Contact = () => {
             <button
               type="submit"
               disabled={isSubmitting}
-              className="mt-6 w-full rounded-full bg-zinc-900 px-5 py-3 text-sm font-semibold text-white transition hover:bg-zinc-800 disabled:opacity-70"
+              className="mt-6 w-full rounded-full bg-zinc-900 px-5 py-3 text-sm font-semibold text-white transition hover:bg-zinc-800 disabled:opacity-70 dark:bg-zinc-100 dark:text-zinc-900 dark:hover:bg-zinc-200"
             >
               {isSubmitting ? 'Bezig met verzenden...' : 'Verstuur bericht'}
             </button>
 
             {result && (
-              <p className="mt-4 text-sm font-medium text-zinc-700">
+              <p className="mt-4 text-sm font-medium text-zinc-700 dark:text-zinc-300">
                 {result}
               </p>
             )}

--- a/src/Pages/Discover.jsx
+++ b/src/Pages/Discover.jsx
@@ -35,28 +35,28 @@ function Discover() {
   return (
     <Layout>
       <main className="mx-auto w-full max-w-6xl px-6 py-14 text-left">
-        <section className="rounded-3xl border border-zinc-200 bg-white p-6 shadow-sm md:p-8">
-          <span className="inline-flex items-center rounded-full border border-zinc-300 bg-zinc-100 px-3 py-1 text-xs font-semibold tracking-wide text-zinc-700">
+        <section className="rounded-3xl border border-zinc-200 bg-white p-6 shadow-sm dark:border-zinc-800 dark:bg-zinc-900 md:p-8">
+          <span className="inline-flex items-center rounded-full border border-zinc-300 bg-zinc-100 px-3 py-1 text-xs font-semibold tracking-wide text-zinc-700 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-300">
             Discover
           </span>
 
-          <h1 className="mt-4 text-4xl font-semibold tracking-tight text-zinc-950 md:text-5xl">
+          <h1 className="mt-4 text-4xl font-semibold tracking-tight text-zinc-950 dark:text-zinc-50 md:text-5xl">
             Projecten & case studies
           </h1>
 
-          <p className="mt-4 max-w-3xl text-base leading-8 text-zinc-700">
+          <p className="mt-4 max-w-3xl text-base leading-8 text-zinc-700 dark:text-zinc-300">
             Gebruik de filters of zoek op technologie, projectnaam of type project.
           </p>
 
           <div className="mt-7 grid gap-4 md:grid-cols-[minmax(0,1fr)_auto] md:items-center">
-            <label className="flex flex-col gap-2 text-sm font-medium text-zinc-700">
+            <label className="flex flex-col gap-2 text-sm font-medium text-zinc-700 dark:text-zinc-300">
               Zoek projecten
               <input
                 type="text"
                 placeholder="Bijv. React, game, PHP..."
                 value={searchTerm}
                 onChange={(e) => setSearchTerm(e.target.value)}
-                className="w-full rounded-xl border border-zinc-300 bg-zinc-50 px-4 py-2.5 text-zinc-900 outline-none focus:border-zinc-500 focus:ring-2 focus:ring-zinc-300"
+                className="w-full rounded-xl border border-zinc-300 bg-zinc-50 px-4 py-2.5 text-zinc-900 outline-none focus:border-zinc-500 focus:ring-2 focus:ring-zinc-300 dark:border-zinc-600 dark:bg-zinc-900 dark:text-zinc-100 dark:focus:border-zinc-400 dark:focus:ring-zinc-700"
               />
             </label>
 
@@ -71,8 +71,8 @@ function Discover() {
                     onClick={() => setActiveFilter(option)}
                     className={`rounded-full border px-3 py-1.5 text-xs font-semibold transition ${
                       isActive
-                        ? "border-zinc-900 bg-zinc-900 text-zinc-100"
-                        : "border-zinc-300 bg-zinc-100 text-zinc-700 hover:bg-zinc-200"
+                        ? "border-zinc-900 bg-zinc-900 text-zinc-100 dark:border-zinc-100 dark:bg-zinc-100 dark:text-zinc-900"
+                        : "border-zinc-300 bg-zinc-100 text-zinc-700 hover:bg-zinc-200 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-300 dark:hover:bg-zinc-700"
                     }`}
                   >
                     {option}
@@ -82,9 +82,9 @@ function Discover() {
             </div>
           </div>
 
-          <div className="mt-6 flex items-center justify-between border-t border-zinc-200 pt-5 text-sm text-zinc-600">
+          <div className="mt-6 flex items-center justify-between border-t border-zinc-200 pt-5 text-sm text-zinc-600 dark:border-zinc-700 dark:text-zinc-400">
             <p>
-              <span className="font-semibold text-zinc-900">
+              <span className="font-semibold text-zinc-900 dark:text-zinc-100">
                 {filteredProjects.length}
               </span>{" "}
               project(en) gevonden
@@ -97,7 +97,7 @@ function Discover() {
                   setSearchTerm("")
                   setActiveFilter(allFilter)
                 }}
-                className="rounded-full border border-zinc-300 bg-zinc-100 px-3 py-1.5 font-medium text-zinc-700 hover:bg-zinc-200"
+                className="rounded-full border border-zinc-300 bg-zinc-100 px-3 py-1.5 font-medium text-zinc-700 hover:bg-zinc-200 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-300 dark:hover:bg-zinc-700"
               >
                 Reset filters
               </button>
@@ -111,7 +111,7 @@ function Discover() {
               <ProjectCard key={project.id} project={project} />
             ))
           ) : (
-            <article className="rounded-2xl border border-dashed border-zinc-300 bg-white p-8 text-center text-zinc-700">
+            <article className="rounded-2xl border border-dashed border-zinc-300 bg-white p-8 text-center text-zinc-700 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-300">
               Geen projecten gevonden met deze filters.
             </article>
           )}

--- a/src/Pages/Home.jsx
+++ b/src/Pages/Home.jsx
@@ -1,4 +1,3 @@
-import { Link } from 'react-router-dom'
 import Layout from '../Components/Layout'
 
 const profileImage = `${import.meta.env.BASE_URL}images/IMG_6841.jpg`
@@ -9,37 +8,31 @@ function Home() {
   return (
     <Layout>
       <main className="mx-auto grid min-h-[calc(100vh-140px)] w-full max-w-6xl items-center gap-12 px-6 py-16 lg:grid-cols-[320px_1fr]">
-        <div className="home-photo-reveal mx-auto w-fitbg-gradient-to-br from-zinc-200 to-zinc-400 p-[6px] shadow-[0_18px_40px_rgba(24,24,27,0.18)] transition-transform duration-300 hover:-translate-y-1">
-          <div className="bg-zinc-300/75 p-2 backdrop-blur-sm">
-            <img
-              src={profileImage}
-              alt="Ricky"
-              className="h-[360px] w-[255px] ] object-cover"
-            />
+        <div className="home-photo-reveal mx-auto w-fit bg-gradient-to-br from-zinc-200 to-zinc-400 p-[6px] shadow-[0_18px_40px_rgba(24,24,27,0.18)] transition-transform duration-300 hover:-translate-y-1 dark:from-zinc-700 dark:to-zinc-900">
+          <div className="bg-zinc-300/75 p-2 backdrop-blur-sm dark:bg-zinc-800/80">
+            <img src={profileImage} alt="Ricky" className="h-[360px] w-[255px] object-cover" />
           </div>
         </div>
 
         <div className="home-content-reveal text-left">
-      
-          <h1 className="mt-5 text-5xl font-semibold tracking-tight text-zinc-950 md:text-6xl">Ricky Saarloos</h1>
+          <h1 className="mt-5 text-5xl font-semibold tracking-tight text-zinc-950 dark:text-zinc-50 md:text-6xl">
+            Ricky Saarloos
+          </h1>
 
           <h2 className="mt-4 flex flex-wrap items-center gap-3 text-2xl font-medium md:text-3xl">
-            <span className="text-zinc-900">software</span>
-            <span className="rounded-lg bg-zinc-900 px-4 py-3 text-zinc-100">developer</span>
- 
+            <span className="text-zinc-900 dark:text-zinc-200">software</span>
+            <span className="rounded-lg bg-zinc-900 px-4 py-3 text-zinc-100 dark:bg-zinc-100 dark:text-zinc-900">developer</span>
           </h2>
 
-          <p className="mt-6 max-w-xl text-base leading-8 text-zinc-700">
+          <p className="mt-6 max-w-xl text-base leading-8 text-zinc-700 dark:text-zinc-300">
             Frontend developer met passie voor design, UX en moderne webtechnologieën.
           </p>
-         
-
 
           <ul className="mt-8 flex flex-wrap gap-3">
             {proofPoints.map((point) => (
               <li
                 key={point}
-                className="rounded-full border border-zinc-300 bg-white/70 px-3 py-1.5 text-sm font-medium text-zinc-700"
+                className="rounded-full border border-zinc-300 bg-white/70 px-3 py-1.5 text-sm font-medium text-zinc-700 dark:border-zinc-700 dark:bg-zinc-900/80 dark:text-zinc-300"
               >
                 {point}
               </li>

--- a/src/Pages/Navigation.jsx
+++ b/src/Pages/Navigation.jsx
@@ -1,8 +1,10 @@
 import { Link, Outlet, useLocation } from 'react-router-dom'
 import { useEffect } from 'react'
+import { useTheme } from '../Components/themeContext'
 
 const Navigation = () => {
   const location = useLocation()
+  const { theme, toggleTheme } = useTheme()
 
   useEffect(() => {
     document.title = `Ricky Saarloos | ${location.pathname === '/' ? 'Home' : location.pathname.slice(1).charAt(0).toUpperCase() + location.pathname.slice(2)}`
@@ -17,8 +19,8 @@ const Navigation = () => {
 
   return (
     <div>
-      <nav className="sticky top-0 z-40 border-b border-zinc-200 bg-zinc-100/90 backdrop-blur">
-        <ul className="mx-auto flex max-w-6xl flex-wrap justify-center gap-2 px-6 py-4">
+      <nav className="sticky top-0 z-40 border-b border-zinc-200 bg-zinc-100/90 backdrop-blur dark:border-zinc-800 dark:bg-zinc-950/90">
+        <ul className="mx-auto flex max-w-6xl flex-wrap items-center justify-center gap-2 px-6 py-4">
           {links.map((link) => {
             const isActive = location.pathname === link.to
             return (
@@ -29,8 +31,8 @@ const Navigation = () => {
                   style={isActive ? { color: '#f8fafc' } : undefined}
                   className={`rounded-full px-4 py-2 text-sm font-medium transition ${
                     isActive
-                      ? 'bg-zinc-800 text-zinc-50 shadow-sm ring-1 ring-zinc-700/30'
-                      : 'text-zinc-700 hover:bg-zinc-200'
+                      ? 'bg-zinc-800 text-zinc-50 shadow-sm ring-1 ring-zinc-700/30 dark:bg-zinc-100 dark:text-zinc-900 dark:ring-zinc-200/40'
+                      : 'text-zinc-700 hover:bg-zinc-200 dark:text-zinc-300 dark:hover:bg-zinc-800'
                   }`}
                 >
                   {link.label}
@@ -38,6 +40,17 @@ const Navigation = () => {
               </li>
             )
           })}
+
+          <li className="ml-2">
+            <button
+              type="button"
+              onClick={toggleTheme}
+              className="rounded-full border border-zinc-300 bg-white px-4 py-2 text-sm font-medium text-zinc-700 transition hover:bg-zinc-100 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-200 dark:hover:bg-zinc-800"
+              aria-label="Wissel tussen lichte en donkere modus"
+            >
+              {theme === 'dark' ? '☀️ Light' : '🌙 Dark'}
+            </button>
+          </li>
         </ul>
       </nav>
       <Outlet />

--- a/src/index.css
+++ b/src/index.css
@@ -1,5 +1,7 @@
 @import "tailwindcss";
 
+@custom-variant dark (&:where(.dark, .dark *));
+
 @theme {
   --font-display: "Playfair Display", serif;
 }
@@ -11,7 +13,7 @@ body,
 }
 
 body {
-  @apply m-0 bg-zinc-100 text-zinc-900 antialiased;
+  @apply m-0 bg-zinc-100 text-zinc-900 antialiased dark:bg-zinc-950 dark:text-zinc-100;
   font-family: var(--font-display);
 }
 


### PR DESCRIPTION
### Motivation
- De site moest een donkere modus krijgen zodat gebruikers kunnen wisselen tussen licht en donker uiterlijk en de voorkeur wordt onthouden.

### Description
- Voeg een `ThemeProvider` en `ThemeContext` toe die thema state beheren, togglen en de `dark` class op `<html>` synchroniseren.
- Implementeer een toggleknop in de navigatie die `useTheme` gebruikt om tussen `light` en `dark` te wisselen.
- Breid `src/index.css` uit met een Tailwind dark-variant (`@custom-variant`) en voeg `dark:`-varianten toe aan Home, About, Contact, Discover, Layout, Footer, ProjectCard, DetailPage en andere componenten om kleuren, borders en achtergronden aan te passen.
- Kleine UX-polish in `Layout` (transities, GitHub-knop styling) en optimalisaties voor formulier- en kaartstijlen in dark mode.

### Testing
- Voer `npm run lint` uit en de linter draaide zonder fouten (geslaagd).
- Voer `npm run build` uit en de productie-build bouwde succesvol (geslaagd).
- Draai de dev-server en verifieer de toggle in de browser met een Playwright-script dat een donker-modus screenshot maakte (artifact aanwezig).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993dff65a348324ab18abf3b90951c4)